### PR TITLE
Upload artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,12 @@ jobs:
       - prepare:
           os: << parameters.os >>
       - build
+      - store_artifacts:
+          path: dist
+      - store_artifacts:
+          path: postject-api.h
+      - store_artifacts:
+          path: postject.py
   
   test:
     parameters:


### PR DESCRIPTION
With this change, it would be possible to use Postject without building
it from source.

Signed-off-by: Darshan Sen <raisinten@gmail.com>