### PR TITLE
ci: add executors for macOS and Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,6 @@ commands:
             equal: [ "win/default", << parameters.os >> ]
           steps:
             - run: choco install cmake.install --installargs '"ADD_CMAKE_TO_PATH=User"'
-            - run: refreshenv
             - run: choco install ninja
 
   build:
@@ -104,7 +103,7 @@ commands:
             equal: [ "win/default", << parameters.os >> ]
           steps:
             - run:
-               command: cd vendor\lief & python ./setup.py --ninja build_ext -b ..\..\dist\lief
+               command: refreshenv & cd vendor\lief & python ./setup.py --ninja build_ext -b ..\..\dist\lief
                shell: cmd.exe
 
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ commands:
             equal: [ "win/default", << parameters.os >> ]
           steps:
             - run:
-               command: cd vendor\lief & python3 ./setup.py --ninja build_ext -b ..\..\dist\lief
+               command: cd vendor\lief & python ./setup.py --ninja build_ext -b ..\..\dist\lief
                shell: cmd.exe
 
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ commands:
             equal: [ "win/default", << parameters.os >> ]
           steps:
             - run: choco install cmake.install --installargs '"ADD_CMAKE_TO_PATH=User"'
+            - run: refreshenv
             - run: choco install ninja
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
           condition:
             equal: [ "win/default", << parameters.os >> ]
           steps:
-            - run: choco install cmake
+            - run: choco install cmake.install --installargs '"ADD_CMAKE_TO_PATH=User"'
             - run: choco install ninja
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,11 +62,11 @@ commands:
             - run: brew install cmake
 
       - when:
-        condition:
-          not:
-            - equal: [ "win/default", << parameters.os >> ]
-        steps:
-          - run: make install-deps EXECUTOR=<< parameters.os >>
+          condition:
+            not:
+              equal: [ "win/default", << parameters.os >> ]
+          steps:
+            - run: make install-deps EXECUTOR=<< parameters.os >>
 
       - when:
           condition:
@@ -76,33 +76,35 @@ commands:
             - run: choco install ninja
 
   build:
+    parameters:
+      <<: *common_parameters
     steps:
       - when:
-        condition:
-          not:
-            - equal: [ "win/default", << parameters.os >> ]
-        steps:
-          - run:
-              # NOTE: the circle ci container executor reports the memory/cpu stats
-              # of the host machine (https://ideas.circleci.com/ideas/CCI-I-578),
-              # `nproc` will return 36 on docker/medium resource_class,
-              # ninja parallelizes accordingly, which leads to overloading
-              # and circleci eventually terminating the builds:
-              #
-              # ninja: job failed: /usr/bin/c++ [...]
-              # c++: fatal error: Killed signal terminated program cc1plus
-              # compilation terminated
-              #
-              # force overwrite job count here:
-              command: make lief JOBS=3
+          condition:
+            not:
+              equal: [ "win/default", << parameters.os >> ]
+          steps:
+            - run:
+                # NOTE: the circle ci container executor reports the memory/cpu stats
+                # of the host machine (https://ideas.circleci.com/ideas/CCI-I-578),
+                # `nproc` will return 36 on docker/medium resource_class,
+                # ninja parallelizes accordingly, which leads to overloading
+                # and circleci eventually terminating the builds:
+                #
+                # ninja: job failed: /usr/bin/c++ [...]
+                # c++: fatal error: Killed signal terminated program cc1plus
+                # compilation terminated
+                #
+                # force overwrite job count here:
+                command: make lief JOBS=3
 
       - when:
           condition:
             equal: [ "win/default", << parameters.os >> ]
           steps:
             - run:
-              command: cd vendor\lief & python3 ./setup.py --ninja build_ext -b ..\..\dist\lief
-              shell: cmd.exe
+               command: cd vendor\lief & python3 ./setup.py --ninja build_ext -b ..\..\dist\lief
+               shell: cmd.exe
 
       - persist_to_workspace:
           root: .
@@ -127,7 +129,8 @@ jobs:
       - checkout
       - prepare:
           os: << parameters.os >>
-      - build
+      - build:
+          os: << parameters.os >>
       - store_artifacts:
           path: dist
       - store_artifacts:
@@ -147,19 +150,22 @@ jobs:
 
 ## WORKFLOWS ##
 
-matrix: &matrix
+build_matrix: &build_matrix
   matrix:
     parameters:
       os: [ alpine, debian, macos, "win/default" ]
+
+test_matrix: &test_matrix
+  matrix:
+    parameters:
+      os: [ alpine, debian, macos ]
 
 workflows:
   postject:
     jobs:
       - build:
-          <<: *matrix
+          <<: *build_matrix
       - test:
-          <<: *matrix
-          matrix:
-            exclude: "win/default"
+          <<: *test_matrix
           requires: [ build-<<matrix.os>> ]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,12 @@ commands:
           steps:
             - run: apt-get update -y && apt-get install -y make
 
+      - when:
+          condition:
+            equal: [ macos, << parameters.os >> ]
+          steps:
+            - run: brew install cmake
+
       - run: make install-deps EXECUTOR=<< parameters.os >>
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,12 @@ version: 2.1
 common_parameters: &common_parameters
   os:
     type: enum
-    enum: [ alpine, debian, linux, macos ]
+    enum: [ alpine, debian, linux, macos, win/default ]
+
+## ORBS ##
+
+orbs:
+  win: circleci/windows@4.1.1
 
 ## EXECUTORS ##
 
@@ -120,7 +125,7 @@ jobs:
 matrix: &matrix
   matrix:
     parameters:
-      os: [ alpine, debian, macos ]
+      os: [ alpine, debian, macos, win/default ]
 
 workflows:
   postject:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 common_parameters: &common_parameters
   os:
     type: enum
-    enum: [ alpine, debian, linux, macos, win/default ]
+    enum: [ alpine, debian, linux, macos, "win/default" ]
 
 ## ORBS ##
 
@@ -61,23 +61,48 @@ commands:
           steps:
             - run: brew install cmake
 
-      - run: make install-deps EXECUTOR=<< parameters.os >>
+      - when:
+        condition:
+          not:
+            - equal: [ "win/default", << parameters.os >> ]
+        steps:
+          - run: make install-deps EXECUTOR=<< parameters.os >>
+
+      - when:
+          condition:
+            equal: [ "win/default", << parameters.os >> ]
+          steps:
+            - run: choco install cmake
+            - run: choco install ninja
 
   build:
     steps:
-      - run:
-          # NOTE: the circle ci container executor reports the memory/cpu stats
-          # of the host machine (https://ideas.circleci.com/ideas/CCI-I-578),
-          # `nproc` will return 36 on docker/medium resource_class,
-          # ninja parallelizes accordingly, which leads to overloading
-          # and circleci eventually terminating the builds:
-          #
-          # ninja: job failed: /usr/bin/c++ [...]
-          # c++: fatal error: Killed signal terminated program cc1plus
-          # compilation terminated
-          #
-          # force overwrite job count here:
-          command: make lief JOBS=3
+      - when:
+        condition:
+          not:
+            - equal: [ "win/default", << parameters.os >> ]
+        steps:
+          - run:
+              # NOTE: the circle ci container executor reports the memory/cpu stats
+              # of the host machine (https://ideas.circleci.com/ideas/CCI-I-578),
+              # `nproc` will return 36 on docker/medium resource_class,
+              # ninja parallelizes accordingly, which leads to overloading
+              # and circleci eventually terminating the builds:
+              #
+              # ninja: job failed: /usr/bin/c++ [...]
+              # c++: fatal error: Killed signal terminated program cc1plus
+              # compilation terminated
+              #
+              # force overwrite job count here:
+              command: make lief JOBS=3
+
+      - when:
+          condition:
+            equal: [ "win/default", << parameters.os >> ]
+          steps:
+            - run:
+              command: cd vendor\lief & python3 ./setup.py --ninja build_ext -b ..\..\dist\lief
+              shell: cmd.exe
 
       - persist_to_workspace:
           root: .
@@ -125,7 +150,7 @@ jobs:
 matrix: &matrix
   matrix:
     parameters:
-      os: [ alpine, debian, macos, win/default ]
+      os: [ alpine, debian, macos, "win/default" ]
 
 workflows:
   postject:
@@ -134,5 +159,7 @@ workflows:
           <<: *matrix
       - test:
           <<: *matrix
+          matrix:
+            exclude: "win/default"
           requires: [ build-<<matrix.os>> ]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,12 +57,6 @@ commands:
 
       - when:
           condition:
-            equal: [ macos, << parameters.os >> ]
-          steps:
-            - run: brew install cmake
-
-      - when:
-          condition:
             not:
               equal: [ "win/default", << parameters.os >> ]
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 common_parameters: &common_parameters
   os:
     type: enum
-    enum: [ alpine, debian, linux ]
+    enum: [ alpine, debian, linux, macos ]
 
 ## EXECUTORS ##
 
@@ -22,6 +22,11 @@ executors:
     resource_class: medium
     machine:
       image: ubuntu-2004:202101-01
+
+  macos:
+    resource_class: medium
+    macos:
+      xcode: 13.4.1
 
 ## COMMANDS ##
 
@@ -109,7 +114,7 @@ jobs:
 matrix: &matrix
   matrix:
     parameters:
-      os: [ alpine, debian ]
+      os: [ alpine, debian, macos ]
 
 workflows:
   postject:

--- a/build/deps.mk
+++ b/build/deps.mk
@@ -16,3 +16,6 @@ ifeq ($(EXECUTOR), alpine)
 		build-base ninja cmake \
 		python3 python3-dev py3-setuptools
 endif
+ifeq ($(EXECUTOR), macos)
+	brew install cmake
+endif

--- a/build/system.mk
+++ b/build/system.mk
@@ -3,13 +3,9 @@ ifndef OS
 
 ifeq ($(shell uname), Linux)
 OS = linux
-endif
-
-ifeq ($(shell uname), Darwin)
+else ifeq ($(shell uname), Darwin)
 OS = macos
-endif
-
-ifeq ($(shell uname -o), Msys)
+else ifeq ($(shell uname -o), Msys)
 OS = windows
 endif
 


### PR DESCRIPTION
Couple of rough edges in this PR but just trying to unblock:

* GitHub is showing the Windows job name as `default` instead of `build-win/default`
* Tests aren't run on Windows currently