### PR TITLE
[skip ci] docs: fix building steps for linux

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,6 +17,7 @@ $ python3 ./setup.py --ninja build_ext -b ..\..\dist\lief
 ### macOS / Linux
 
 ```sh
+$ sudo make install-deps
 $ make lief
 ```
 


### PR DESCRIPTION
The step for installation dependencies was missing.

Signed-off-by: Darshan Sen <raisinten@gmail.com>