### PR TITLE
ci: build and test on linux on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,11 +49,15 @@ commands:
 
       - when:
           condition:
-            or:
-              - equal: [ debian, << parameters.os >> ]
-              - equal: [ linux, << parameters.os >> ]
+            equal: [ debian, << parameters.os >> ]
           steps:
             - run: apt-get update -y && apt-get install -y make
+
+      - when:
+          condition:
+            equal: [ linux, << parameters.os >> ]
+          steps:
+            - run: sudo apt-get update -y && sudo apt-get install -y make
 
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,12 +147,12 @@ jobs:
 build_matrix: &build_matrix
   matrix:
     parameters:
-      os: [ alpine, debian, macos, "win/default" ]
+      os: [ alpine, debian, linux, macos, "win/default" ]
 
 test_matrix: &test_matrix
   matrix:
     parameters:
-      os: [ alpine, debian, macos ]
+      os: [ alpine, debian, linux, macos ]
 
 workflows:
   postject:

--- a/build/deps.mk
+++ b/build/deps.mk
@@ -4,9 +4,15 @@ EXECUTOR ?= $(OS)
 .PHONY: install-deps
 install-deps:
 # this assumes the linux executor on CircleCI runs ubuntu/debian
-ifneq (,$(filter $(EXECUTOR),debian linux))
+ifneq (,$(filter $(EXECUTOR),debian))
 	apt-get update
 	apt-get install --no-install-recommends -y \
+		build-essential ninja-build cmake \
+		python3 python3-dev python3-setuptools
+endif
+ifneq (,$(filter $(EXECUTOR),linux))
+	sudo apt-get update
+	sudo apt-get install --no-install-recommends -y \
 		build-essential ninja-build cmake \
 		python3 python3-dev python3-setuptools
 endif


### PR DESCRIPTION
The only Linux distributions we were building and testing on are alpine and debian. This change also adds the linux executor which was unused.

Signed-off-by: Darshan Sen <raisinten@gmail.com>