### PR TITLE
build: stop building and testing on `alpine` and `debian`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 common_parameters: &common_parameters
   os:
     type: enum
-    enum: [ alpine, debian, linux, macos, "win/default" ]
+    enum: [ linux, macos, "win/default" ]
 
 ## ORBS ##
 
@@ -13,16 +13,6 @@ orbs:
 ## EXECUTORS ##
 
 executors:
-  alpine:
-    resource_class: medium
-    docker:
-      - image: docker.io/library/alpine:3.16
-
-  debian:
-    resource_class: medium
-    docker:
-      - image: docker.io/library/debian:11
-
   linux:
     resource_class: medium
     machine:
@@ -41,18 +31,6 @@ commands:
       <<: *common_parameters
     steps:
       # NOTE: minimal effort to allow moving most conditionals out of ci config
-      - when:
-          condition:
-            equal: [ alpine, << parameters.os >> ]
-          steps:
-            - run: apk add -U make
-
-      - when:
-          condition:
-            equal: [ debian, << parameters.os >> ]
-          steps:
-            - run: apt-get update -y && apt-get install -y make
-
       - when:
           condition:
             equal: [ linux, << parameters.os >> ]
@@ -151,12 +129,12 @@ jobs:
 build_matrix: &build_matrix
   matrix:
     parameters:
-      os: [ alpine, debian, linux, macos, "win/default" ]
+      os: [ linux, macos, "win/default" ]
 
 test_matrix: &test_matrix
   matrix:
     parameters:
-      os: [ alpine, debian, linux, macos ]
+      os: [ linux, macos ]
 
 workflows:
   postject:

--- a/build/deps.mk
+++ b/build/deps.mk
@@ -3,24 +3,11 @@ EXECUTOR ?= $(OS)
 
 .PHONY: install-deps
 install-deps:
-# this assumes the linux executor on CircleCI runs ubuntu/debian
-ifneq (,$(filter $(EXECUTOR),debian))
-	apt-get update
-	apt-get install --no-install-recommends -y \
-		build-essential ninja-build cmake \
-		python3 python3-dev python3-setuptools
-endif
 ifneq (,$(filter $(EXECUTOR),linux))
 	sudo apt-get update
 	sudo apt-get install --no-install-recommends -y \
 		build-essential ninja-build cmake \
 		python3 python3-dev python3-setuptools
-endif
-ifeq ($(EXECUTOR), alpine)
-	apk update
-	apk add --no-cache \
-		build-base ninja cmake \
-		python3 python3-dev py3-setuptools
 endif
 ifeq ($(EXECUTOR), macos)
 	brew install cmake


### PR DESCRIPTION
After https://github.com/postmanlabs/postject/pull/24 landed, we started building and testing on the `linux` executor, so there's no need to use the `alpine` and `debian` executors anymore.

Signed-off-by: Darshan Sen <raisinten@gmail.com>