### PR TITLE
chore: enforce `linefeeds` at `eol`s in the `.gitattributes` file [skip ci]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.c text eol=lf
+*.cc text eol=lf
+*.h text eol=lf
+*.js text eol=lf
+*.markdown text eol=lf
+*.mjs text eol=lf


### PR DESCRIPTION
We should avoid making changes to the global git config if we can help it. This change stops setting the value for `core.autocrlf` globally on CI by moving it to the `.gitattributes` file which is local to a git repository.

This should help out with removing this change from
https://github.com/postmanlabs/postject/pull/8/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R68-R69.

Refs: https://stackoverflow.com/a/52996849
Signed-off-by: Darshan Sen <raisinten@gmail.com>