### PR TITLE
chore: add `.npmignore` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+build/
+.circleci/
+CMakeLists.txt
+CODEOWNERS
+DEPENDENCIES
+postject-api.h
+scripts/
+src/
+test/
+vendor/


### PR DESCRIPTION
This excludes the files that we don't want to publish to the npm package.

Signed-off-by: Darshan Sen <raisinten@gmail.com>