### PR TITLE
chore: use `alpha` instead of `dev` in package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postject",
-  "version": "1.0.0-dev",
+  "version": "1.0.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postject",
-      "version": "1.0.0-dev",
+      "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^9.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postject",
-  "version": "1.0.0-dev",
+  "version": "1.0.0-alpha.1",
   "description": "Easily inject arbitrary read-only resources into executable formats (Mach-O, PE, ELF) and use it at runtime.",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
I think this was the intended version. (reasons discussed in DMs)

Signed-off-by: Darshan Sen <raisinten@gmail.com>