### PR TITLE
fix: exclude `dist/postject-api.h` from `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ scripts/
 src/
 test/
 vendor/
+!dist/postject-api.h


### PR DESCRIPTION
I think having `postject-api.h` in the `.npmignore` file caused the copied file inside `dist/` to get excluded from the package built with `npm pack`. Explicitly including it fixes the problem.

Signed-off-by: Darshan Sen <raisinten@gmail.com>