### PR TITLE
chore: remove `.gitattributes` and `.github/` from `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,8 @@ build/
 CMakeLists.txt
 CODEOWNERS
 DEPENDENCIES
+.gitattributes
+.github/
 postject-api.h
 scripts/
 src/


### PR DESCRIPTION
This is what the package would look like after this change:
```sh
$ tar -xvf postject-1.0.0-alpha.1.tgz
$ tree -a package
package
├── LICENSE
├── README.markdown
├── dist
│   ├── main.js
│   ├── postject-api.h
│   ├── postject.js
│   └── postject.wasm
└── package.json
```

I did `tree` without the `-a` and that's why I missed the `.` files initially. :)

Signed-off-by: Darshan Sen <raisinten@gmail.com>