### PR TITLE
fix: OOM abort error while injecting data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 add_subdirectory(vendor/lief)
 
 add_executable(postject src/postject.cpp)
-set_target_properties(postject PROPERTIES LINK_FLAGS "-sMODULARIZE=1 -sALLOW_MEMORY_GROWTH --bind")
+set_target_properties(postject PROPERTIES LINK_FLAGS "-sMODULARIZE=1 -sALLOW_MEMORY_GROWTH -sINITIAL_MEMORY=268435456 -sMAXIMUM_MEMORY=4294967296 --bind")
 
 if(MSVC)
   set_property(TARGET postject PROPERTY LINK_FLAGS /NODEFAULTLIB:MSVCRT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 add_subdirectory(vendor/lief)
 
 add_executable(postject src/postject.cpp)
-set_target_properties(postject PROPERTIES LINK_FLAGS "-sMODULARIZE=1 --bind")
+set_target_properties(postject PROPERTIES LINK_FLAGS "-sMODULARIZE=1 -sALLOW_MEMORY_GROWTH --bind")
 
 if(MSVC)
   set_property(TARGET postject PROPERTY LINK_FLAGS /NODEFAULTLIB:MSVCRT)

--- a/test/cli.mjs
+++ b/test/cli.mjs
@@ -132,5 +132,5 @@ describe("Inject data into Node.js", () => {
       });
       expect(status).to.equal(0);
     }
-  }).timeout(50000);
+  }).timeout(60000);
 });

--- a/test/cli.mjs
+++ b/test/cli.mjs
@@ -88,3 +88,49 @@ describe("postject CLI", () => {
     }
   }).timeout(30000);
 });
+
+describe("Inject data into Node.js", () => {
+  let filename;
+  let tempDir;
+  let resourceContents;
+  let resourceFilename;
+
+  beforeEach(async () => {
+    tempDir = temporaryDirectory();
+    await fs.ensureDir(tempDir);
+
+    filename = path.join(tempDir, path.basename(process.execPath));
+
+    await fs.copy(process.execPath, filename);
+
+    resourceContents = crypto.randomBytes(64).toString("hex");
+    resourceFilename = path.join(tempDir, "resource.bin");
+    await fs.writeFile(resourceFilename, resourceContents);
+  });
+
+  afterEach(() => {
+    rimraf.sync(tempDir);
+  });
+
+  it("should inject a resource successfully", async () => {
+    {
+      const { status, stdout, stderr } = spawnSync(
+        "node",
+        ["./dist/main.js", filename, "foobar", resourceFilename],
+        { encoding: "utf-8" }
+      );
+      // TODO(dsanders11) - Enable this once we squelch LIEF warnings
+      // expect(stderr).to.be.empty;
+      expect(stdout).to.be.empty;
+      expect(status).to.equal(0);
+    }
+
+    // After injection
+    {
+      const { status } = spawnSync(filename, ["-e", "process.exit()"], {
+        encoding: "utf-8",
+      });
+      expect(status).to.equal(0);
+    }
+  }).timeout(40000);
+});

--- a/test/cli.mjs
+++ b/test/cli.mjs
@@ -132,5 +132,5 @@ describe("Inject data into Node.js", () => {
       });
       expect(status).to.equal(0);
     }
-  }).timeout(40000);
+  }).timeout(50000);
 });


### PR DESCRIPTION
After building Postject with `-sASSERTIONS` enabled, the error looked like this:
```
Aborted(Cannot enlarge memory arrays to size 82239488 bytes (OOM). Either (1) compile with -sINITIAL_MEMORY=X with X higher than the current value 16777216, (2) compile with -sALLOW_MEMORY_GROWTH which allows increasing the size at runtime, or (3) if you want malloc to return NULL (0) instead of this abort, compile with -sABORTING_MALLOC=0)
```
so I followed option 2 in this change.

Fixes: https://github.com/postmanlabs/postject/issues/42
Signed-off-by: Darshan Sen <raisinten@gmail.com>