### PR TITLE
fix: get rid of undefined symbols from the bundled api

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -39,14 +39,13 @@ await fs.copy("../src/cli.js", "../dist/cli.js");
 await fs.copy("../postject-api.h", "../dist/postject-api.h");
 
 // Repace all occurrences of `__filename` and `__dirname` with "" because
-// Node.js core doesn't support it.
+// Node.js core doesn't support it. These uses are functionally dead when
+// `SINGLE_FILE` is enabled anyways.
 // Refs: https://github.com/postmanlabs/postject/issues/50
 // TODO(RaisinTen): Send a PR to emsdk to get rid of these symbols from the
 // affected code paths when `SINGLE_FILE` is enabled.
 const contents = await fs.readFile("../dist/api.js", "utf-8");
-const replaced = contents
-  .replace(/__filename/gi, "''")
-  .replace(/__dirname/, "''");
+const replaced = contents.replace(/\b__filename\b|\b__dirname\b/g, "''");
 await fs.writeFile("../dist/api.js", replaced);
 
 // Build tests

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -38,6 +38,17 @@ await $`esbuild api.js --bundle --platform=node --outfile=../dist/api.js`;
 await fs.copy("../src/cli.js", "../dist/cli.js");
 await fs.copy("../postject-api.h", "../dist/postject-api.h");
 
+// Repace all occurrences of `__filename` and `__dirname` with "" because
+// Node.js core doesn't support it.
+// Refs: https://github.com/postmanlabs/postject/issues/50
+// TODO(RaisinTen): Send a PR to emsdk to get rid of these symbols from the
+// affected code paths when `SINGLE_FILE` is enabled.
+const contents = await fs.readFile("../dist/api.js", "utf-8");
+const replaced = contents
+  .replace(/__filename/gi, "''")
+  .replace(/__dirname/, "''");
+await fs.writeFile("../dist/api.js", replaced);
+
 // Build tests
 if (!(await fs.exists("./test"))) {
   await $`mkdir test`;

--- a/test/cli.mjs
+++ b/test/cli.mjs
@@ -231,3 +231,19 @@ describe("Inject data into Node.js using API", () => {
     }
   }).timeout(70000);
 });
+
+describe("api.js should not contain __filename and __dirname", () => {
+  let contents;
+
+  before(async () => {
+    contents = await fs.readFile("./dist/api.js", "utf-8");
+  });
+
+  it("should not contain __filename", () => {
+    expect(contents).to.not.have.string("__filename");
+  });
+
+  it("should not contain __dirname", () => {
+    expect(contents).to.not.have.string("__dirname");
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/postmanlabs/postject/issues/50
Signed-off-by: Darshan Sen <raisinten@gmail.com>