### PR TITLE
docs: make postject ready for transferring to the nodejs org

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Code of Conduct
+
+Postject is committed to upholding the Node.js Code of Conduct.
+
+The Node.js Code of Conduct document can be found at
+https://github.com/nodejs/admin/blob/main/CODE_OF_CONDUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license
+  indicated in the file; or
+
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source
+  license and I have the right under that license to submit that
+  work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am
+  permitted to submit under a different license), as indicated
+  in the file; or
+
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified
+  it.
+
+* (d) I understand and agree that this project and the contribution
+  are public and that a record of the contribution (including all
+  personal information I submit with it, including my sign-off) is
+  maintained indefinitely and may be redistributed consistent with
+  this project or the open source license(s) involved.
+
+## Moderation Policy
+
+The [Node.js Moderation Policy] applies to this project.
+
+[Node.js Moderation Policy]:
+https://github.com/nodejs/admin/blob/main/Moderation-Policy.md


### PR DESCRIPTION
This change adds a `CODE_OF_CONDUCT.md` file and a `CONTRIBUTING.md` file to the project. This is a requirement for transferring as documented in: https://github.com/nodejs/admin/blob/a99c444662467d596753affb2ce192250f4f4b6c/transfer-repo-into-the-org.md#step-1-get-the-repository-ready.

Refs: https://github.com/nodejs/admin/issues/739
Signed-off-by: Darshan Sen <raisinten@gmail.com>