### PR TITLE
chore: remove Postman copyright from `postject-api.h`

### DIFF
--- a/postject-api.h
+++ b/postject-api.h
@@ -1,5 +1,3 @@
-// Copyright (c) 2022 Postman, Inc.
-
 #ifndef POSTJECT_API_H_
 #define POSTJECT_API_H_
 


### PR DESCRIPTION
No need for it.

Refs: https://github.com/nodejs/node/pull/45038#discussion_r1005654541
Signed-off-by: Darshan Sen <raisinten@gmail.com>